### PR TITLE
Handle arenas with numbers of corners other than 4

### DIFF
--- a/arena.html
+++ b/arena.html
@@ -53,9 +53,10 @@
                 return {arena: tokens[0], corner: tokens[1]};
             };
 
-            var setUpNormal = function(args, comp) {
+            var setUpNormal = function(args, comp, numCorners) {
                 var arena = document.querySelector('#arena');
                 var errorClock = document.querySelector('#error-clock');
+                arena.showOtherCorners = numCorners == 4;
                 arena.hidden = false;
                 arena.arena = args.arena;
                 arena.maincorner = args.corner;
@@ -78,9 +79,10 @@
                     comp.stream.load();
                 } else {
                     comp.api.getArena(args.arena, function(compArena) {
-                        comp.api.getCorner(args.corner, function(compCorner) {
-                            if (compArena && compCorner) {
-                                setUpNormal(args, comp);
+                        comp.api.getCorners(function(compCorners) {
+                            if (compArena && compCorners[args.corner]) {
+                                var numCorners = Object.keys(compCorners).length;
+                                setUpNormal(args, comp, numCorners);
                             } else {
                                 var picker = document.querySelector('#picker');
                                 picker.hidden = false;

--- a/components/sr-arena/component.html
+++ b/components/sr-arena/component.html
@@ -34,11 +34,13 @@
 
         <sr-corner id="corner0" show="all"></sr-corner>
 
-        <div>
-            <sr-corner id="corner1" show="tla"></sr-corner>
-            <sr-corner id="corner2" show="tla"></sr-corner>
-            <sr-corner id="corner3" show="tla"></sr-corner>
-        </div>
+        <template if="{{ showOtherCorners }}">
+            <div>
+                <sr-corner id="corner1" show="tla"></sr-corner>
+                <sr-corner id="corner2" show="tla"></sr-corner>
+                <sr-corner id="corner3" show="tla"></sr-corner>
+            </div>
+        </template>
     </template>
 
     <script>
@@ -46,6 +48,7 @@
             comp: null,
             arena: null,
             maincorner: 0,
+            showOtherCorners: true,
             arenaChanged: function() {
                 var corners = this.shadowRoot.querySelectorAll('sr-corner');
                 for (var i = 0; i < corners.length; i++) {
@@ -53,23 +56,25 @@
                 }
             },
             maincornerChanged: function() {
-                var otherCorners = [0, 1, 2, 3];
-                otherCorners.splice(this.maincorner, 1);
-
                 var corners = this.shadowRoot.querySelectorAll('sr-corner');
-                for (var i = 0; i < corners.length; i++) {
-                    if (i == 0) {
-                        corners[i].corner = this.maincorner;
-                    } else {
+                corners[0].corner = this.maincorner;
+
+                if (this.showOtherCorners) {
+                    var otherCorners = [0, 1, 2, 3];
+                    otherCorners.splice(this.maincorner, 1);
+
+                    for (var i = 1; i < corners.length; i++) {
                         corners[i].corner = otherCorners[i - 1];
                     }
                 }
             },
             compChanged: function() {
                 this.$.corner0.comp = this.comp;
-                this.$.corner1.comp = this.comp;
-                this.$.corner2.comp = this.comp;
-                this.$.corner3.comp = this.comp;
+                if (this.showOtherCorners) {
+                    this.$.corner1.comp = this.comp;
+                    this.$.corner2.comp = this.comp;
+                    this.$.corner3.comp = this.comp;
+                }
             }
         });
     </script>

--- a/components/sr-competitor-schedule/component.html
+++ b/components/sr-competitor-schedule/component.html
@@ -36,7 +36,7 @@
                 <th></th>
                 <template repeat="{{ arena in arenasList }}">
                     <th></th>
-                    <th colspan="4" style="background-color: {{ arenas[arena].colour | arenaColour }}">{{ arenas[arena].display_name }}</th>
+                    <th colspan="{{ cornersList.length }}" style="background-color: {{ arenas[arena].colour | arenaColour }}">{{ arenas[arena].display_name }}</th>
                 </template>
             </tr>
 
@@ -46,7 +46,7 @@
                     <td><time datetime="{{ match.gameStart }}"></time></td>
                     <template repeat="{{ arena in arenasList }}">
                         <td style="width: 0.1em;"></td>
-                        <template repeat="{{ corner in [0, 1, 2, 3] }}">
+                        <template repeat="{{ corner in cornersList }}">
                             <td style="background-color: {{ arenas[arena].colour | arenaColour }}">
                                 <span style="color: {{ corners[corner].colour }}">
                                     {{ match.arenas[arena].teams[corner] || '—' }}
@@ -67,6 +67,7 @@
             arenas: undefined,
             arenasList: undefined,
             corners: undefined,
+            cornersList: undefined,
             back: 1,
             forward: 6,
             schedule: {},
@@ -104,6 +105,7 @@
 
                 this.comp.api.getCorners(function(corners) {
                     this.corners = corners;
+                    this.cornersList = Object.keys(corners);
                     this.updateSchedule();
                 }.bind(this));
 
@@ -117,7 +119,7 @@
             },
             updateSchedule: function() {
                 if (this.arenasList == null || this.arenas == null
-                    || this.corners == null) {
+                    || this.cornersList == null || this.corners == null) {
                     return;  // wait until they're set
                 }
 

--- a/components/sr-shepherd-schedule/component.html
+++ b/components/sr-shepherd-schedule/component.html
@@ -36,7 +36,7 @@
                 <th>Staging Closes</th>
                 <template repeat="{{ arena in arenasList }}">
                     <th></th>
-                    <th colspan="4" style="background-color: {{ arenas[arena].colour | arenaColour }}">{{ arenas[arena].display_name }}</th>
+                    <th colspan="{{ numCorners }}" style="background-color: {{ arenas[arena].colour | arenaColour }}">{{ arenas[arena].display_name }}</th>
                 </template>
             </tr>
 
@@ -62,6 +62,7 @@
             comp: null,
             arenas: undefined,
             arenasList: undefined,
+            numCorners: undefined,
             locations: undefined,
             teams: undefined,
             back: 1,
@@ -110,6 +111,11 @@
                     this.updateSchedule();
                 }.bind(this));
 
+                this.comp.api.getCorners(function(corners) {
+                    this.numCorners = Object.keys(corners).length;
+                    this.updateSchedule();
+                }.bind(this));
+
                 this.comp.api.getLocations(function(locations) {
                     this.locations = locations;
                     this.updateSchedule();
@@ -130,7 +136,8 @@
             },
             updateSchedule: function() {
                 if (this.arenasList == null || this.arenas == null
-                    || this.locations == null || this.teams == null) {
+                    || this.locations == null || this.teams == null
+                    || this.numCorners == null) {
                     return;  // wait until they're set
                 }
 

--- a/components/sr-staging-schedule/component.html
+++ b/components/sr-staging-schedule/component.html
@@ -37,7 +37,7 @@
                 <th>Staging Opens</th>
                 <template repeat="{{ arena in arenasList }}">
                     <th></th>
-                    <th colspan="4" style="background-color: {{ arenas[arena].colour | arenaColour }}">{{ arenas[arena].display_name }}</th>
+                    <th colspan="{{ cornersList.length }}" style="background-color: {{ arenas[arena].colour | arenaColour }}">{{ arenas[arena].display_name }}</th>
                 </template>
             </tr>
 
@@ -48,7 +48,7 @@
                     <td><time class="staging" datetime="{{ match.stagingStart }}/{{ match.stagingEnd }}"></time></td>
                     <template repeat="{{ arena in arenasList }}">
                         <td style="width: 0.1em;"></td>
-                        <template repeat="{{ corner in [0, 1, 2, 3] }}">
+                        <template repeat="{{ corner in cornersList }}">
                             <td style="background-color: {{ arenas[arena].colour | arenaColour }}">
                                 <span style="color: {{ corners[corner].colour }}">
                                     {{ match.arenas[arena].teams[corner] || '—' }}
@@ -69,6 +69,7 @@
             arenas: undefined,
             arenasList: undefined,
             corners: undefined,
+            cornersList: undefined,
             back: 1,
             forward: 7,
             schedule: {},
@@ -124,6 +125,7 @@
 
                 this.comp.api.getCorners(function(corners) {
                     this.corners = corners;
+                    this.cornersList = Object.keys(corners);
                     this.updateSchedule();
                 }.bind(this));
 
@@ -137,7 +139,7 @@
             },
             updateSchedule: function() {
                 if (this.arenasList == null || this.arenas == null
-                    || this.corners == null) {
+                    || this.cornersList == null || this.corners == null) {
                     return;  // wait until they're set
                 }
 


### PR DESCRIPTION
The approach for the arena displays is a bit blunt as ideally we'd automatically adapt to the right number of corners.

The other displays are somewhat easier to cope with as they're just tables, so they do now adapt to the given number of corners.