### PR TITLE
Cycle through outlines when a team TLA is touched on the shepherding screen

### DIFF
--- a/components/sr-shepherd-schedule/component.html
+++ b/components/sr-shepherd-schedule/component.html
@@ -28,6 +28,12 @@
                 opacity: 0.8;
                 font-size: 1.3em;
             }
+
+            .team {
+                border-radius: 0.5em;
+                border-width: 3px;
+                padding-block: calc(0.25em - 3px);
+            }
         </style>
 
         <table>
@@ -47,7 +53,12 @@
                     <template repeat="{{ arena in arenasList }}">
                         <td style="width: 0.1em;"></td>
                         <template repeat="{{ team in match.arenas[arena].teams }}">
-                            <td style="color: {{ locations[teams[team].location.name].shepherds.colour }}">{{ team || '—' }}</td>
+                            <td class="team"
+                                style="color: {{ locations[teams[team].location.name].shepherds.colour }}; border-style: {{ teamOutline[team] || 'none' }}"
+                                data-team-tla="{{team}}"
+                                on-click="{{handleTeamClick}}">
+                                {{ team || '—' }}
+                            </td>
                         </template>
                     </template>
                 </tr>
@@ -58,6 +69,16 @@
     <script src="../../node_modules/moment/moment.js"></script>
 
     <script>
+        const nextOutline = (currentOutline) => {
+            switch (currentOutline) {
+                default:
+                case 'none':   return 'dotted';
+                case 'dotted': return 'dashed';
+                case 'dashed': return 'solid';
+                case 'solid':  return 'none';
+            }
+        };
+
         Polymer({
             comp: null,
             arenas: undefined,
@@ -65,9 +86,15 @@
             numCorners: undefined,
             locations: undefined,
             teams: undefined,
+            /** Maps team TLAs to a border style to be applied to their entries. */
+            teamOutline: {},
             back: 1,
             forward: 7,
             schedule: {},
+            handleTeamClick: function(ev, detail, sender) {
+                const tla = sender.dataset.teamTla;
+                this.teamOutline[tla] = nextOutline(this.teamOutline[tla]);
+            },
             ready: function() {
                 setInterval(this._updateDisplayedTimes.bind(this), 5000);
             },

--- a/components/sr-shepherd-schedule/component.html
+++ b/components/sr-shepherd-schedule/component.html
@@ -34,6 +34,14 @@
                 border-width: 3px;
                 padding-block: calc(0.25em - 3px);
             }
+
+            #clear-outlines-button {
+                background: none;
+                border: none;
+                color: lightblue;
+                font-size: inherit;
+                width: 100%;
+            }
         </style>
 
         <table>
@@ -64,6 +72,11 @@
                 </tr>
             </template>
         </table>
+        <template if="{{showClearButton}}">
+        <button id="clear-outlines-button" on-click="{{clearTeamOutlines}}">
+            ⎚ Clear outlines
+        </button>
+        </template>
     </template>
 
     <script src="../../node_modules/moment/moment.js"></script>
@@ -88,12 +101,18 @@
             teams: undefined,
             /** Maps team TLAs to a border style to be applied to their entries. */
             teamOutline: {},
+            showClearButton: false,
             back: 1,
             forward: 7,
             schedule: {},
+            clearTeamOutlines: function() {
+                this.teamOutline = {};
+                this.showClearButton = false;
+            },
             handleTeamClick: function(ev, detail, sender) {
                 const tla = sender.dataset.teamTla;
                 this.teamOutline[tla] = nextOutline(this.teamOutline[tla]);
+                this.showClearButton = true;
             },
             ready: function() {
                 setInterval(this._updateDisplayedTimes.bind(this), 5000);


### PR DESCRIPTION
When a team TLA is touched on the shepherding screen, cycle through four different outline styles (dotted, dashed, solid, and none) for that team. This is a much cleaner version of some code I hacked together at the competition in 2024. For a head shepherd, it's useful for keeping track of the status of teams who are (or should be) on their way to the arena.

Personally, I use it as follows. When one of my shepherds has told a team that they're up soon, I touch their TLA to outline it with dots. When they've been spotted heading to the arena, I touch it again for a dashed outline, and once they're seen in the Cube I touch a final time to a show a solid border. This provides an at-a-glance overview of where teams are, how the next match lineup is looking, and who we need to chase.