### PR TITLE
Implement a screen for livestream producers

### DIFF
--- a/components/sr-producer/component.html
+++ b/components/sr-producer/component.html
@@ -1,0 +1,127 @@
+<link rel="import" href="../../bower_components/polymer/polymer.html" />
+
+<link rel="import" href="../sr-clock/component.html" />
+<link rel="import" href="../sr-corner-clock/component.html" />
+<link rel="import" href="../sr-delay/component.html" />
+
+<polymer-element name="sr-producer" attributes="arena comp">
+    <template>
+        <style>
+            :host {
+                display: flex;
+                display: -webkit-flex;
+                flex-direction: column;
+                -webkit-flex-direction: column;
+                align-items: center;
+                -webkit-align-items: center;
+                justify-content: space-between;
+                height: 100%;
+            }
+
+            #title {
+                margin: 0.6em 0 0;
+            }
+
+            sr-corner-clock h1 {
+                margin: 0;
+            }
+
+            #time {
+                flex: 0 0 auto;
+                -webkit-flex: 0 0 auto;
+
+                width: 100%;
+
+                display: flex;
+                display: -webkit-flex;
+                flex-direction: row;
+                -webkit-flex-direction: row;
+
+                border-top: 1px solid white;
+                background: rgb(50, 50, 50);
+            }
+
+            sr-clock, sr-delay {
+                flex: 1 1 auto;
+                -webkit-flex: 1 1 auto;
+
+                text-align: center;
+
+                margin: 0.1em;
+                font-size: 3.6em;
+            }
+
+            sr-corner-clock h1 {
+                font-size: 3.6em;
+            }
+        </style>
+
+        <h1 id="title">Producer</h1>
+
+        <div>
+            <h2>Match {{ match.num }}</h2>
+            <sr-corner-clock id="clock"></sr-corner-clock>
+        </div>
+
+
+        <div id="time">
+            <sr-clock></sr-clock>
+            <sr-delay id="delay"></sr-delay>
+        </div>
+    </template>
+
+    <script>
+        var reload = function() {
+            if (this.comp == null || this.arena == null) {
+                return;
+            }
+
+            this.$.delay.comp = this.comp;
+
+            this.comp.stream.addEventListener('match', function(e) {
+                var matches = e.detail.filter(function(match) {
+                    return match.arena === this.arena;
+                }.bind(this));
+
+                if (matches.length) {
+                    this.match = matches[0];
+                } else {
+                    this.match = null;
+
+                    this.comp.api.getUpcomingMatches(this.arena, function(matches) {
+                        // only update if we haven't since updated the match
+                        if (this.match == null && matches.length) {
+                            this.match = matches[0];
+                        }
+                    }.bind(this));
+                }
+            }.bind(this));
+
+            this.comp.stream.addEventListener('knockouts', function() {
+                var updateMatch = function(matches) {
+                    // only update if it's the same match
+                    var newMatch = matches[0];
+                    if (this.match != null && newMatch != null && this.match.num == newMatch.num) {
+                        this.match = newMatch;
+                    }
+                }.bind(this);
+
+                if (this.match) {
+                    this.comp.api.getMatch(this.arena, this.match.num, updateMatch);
+                } else {
+                    this.comp.api.getUpcomingMatches(this.arena, updateMatch);
+                }
+            }.bind(this));
+        };
+        Polymer({
+            comp: null,
+            compChanged: reload,
+            arenaChanged: reload,
+            match: undefined,
+            matchChanged: function() {
+                this.$.clock.match = this.match;
+                this.fire('match', this.match);
+            }
+        });
+    </script>
+</polymer-element>

--- a/producer.html
+++ b/producer.html
@@ -1,0 +1,104 @@
+<!DOCTYPE html>
+<html lang="en">
+    <head>
+        <meta charset="UTF-8" />
+        <title>SR Producer Screen</title>
+
+        <script src="bower_components/webcomponentsjs/webcomponents.js"></script>
+
+        <link rel="import" href="components/sr-comp/component.html" />
+        <link rel="import" href="components/sr-arena-picker/component.html" />
+        <link rel="import" href="components/sr-producer/component.html" />
+
+        <style>
+            body {
+                position: fixed;
+                width: 100%;
+                height: 100%;
+                top: 0;
+                right: 0;
+                bottom: 0;
+                left: 0;
+                margin: 0;
+                padding: 0;
+
+                font-family: 'Open Sans', sans-serif;
+                background: black;
+                color: white;
+                font-size: 85%;
+            }
+
+            #arena {
+                width: 100%;
+                height: 100%;
+
+                overflow: auto;
+            }
+        </style>
+    </head>
+
+    <body>
+        <sr-comp id="comp"></sr-comp>
+
+        <sr-arena-picker id="picker" hidden></sr-arena-picker>
+        <sr-producer id="producer" hidden></sr-producer>
+
+        <script>
+            var parseArguments = function() {
+                var fragment = window.location.search;
+                var arena = fragment.substr(1);
+                return {arena: arena};
+            };
+
+            var setUpNormal = function(arena, comp) {
+                var producer = document.querySelector('#producer');
+                producer.hidden = false;
+                producer.arena = arena;
+                producer.comp = comp;
+            };
+
+            document.addEventListener('sr-ready', function() {
+                var args = parseArguments();
+
+                var comp = document.querySelector('#comp');
+
+                if (!args.arena) {
+                    var picker = document.querySelector('#picker');
+                    picker.hidden = false;
+                    picker.comp = comp;
+                    comp.stream.load();
+                } else {
+                    comp.api.getArena(args.arena, function(compArena) {
+                        if (compArena) {
+                            setUpNormal(args.arena, comp);
+                        } else {
+                            var picker = document.querySelector('#picker');
+                            picker.hidden = false;
+                            picker.comp = comp;
+                        }
+
+                        /* Work around an issue with Firefox. When the
+                            arena fields above are set, the changed callback
+                            should get called immediately giving time for
+                            listeners to be registered on the stream before
+                            it is loaded below. However, in Firefox, the
+                            changed callbacks happen *after* this call
+                            below. Therefore, we wrap it in a 'setTimeout'
+                            to ensure it happens in the next tick, after
+                            the changed callbacks.
+
+                            Rather concerningly, using a value of 0ms in the
+                            'setTimeout' doesn't solve the problem.
+                            Therefore the 500ms as it is currently might
+                            have to be increased for the Raspberry Pis which
+                            have a lower processing speed than my laptop. */
+
+                        setTimeout(function() {
+                            comp.stream.load();
+                        }, 500);
+                    });
+                }
+            });
+        </script>
+    </body>
+</html>


### PR DESCRIPTION
Pretty basic for now, but covers the core of what they've asked for:

- time to the current/next match (uses the corner countdown, which is actually what they use already)
- highlight when delays happen (relying on this having been rolled into the `sr-delay` component generally https://github.com/srobo/srcomp-screens/pull/10)

![image](https://github.com/user-attachments/assets/88ed2ee1-97ce-4f73-89bd-8f4826cb3735)
