### PR TITLE
Support for "match releasing"

### DIFF
--- a/components/sr-comp-stream/component.html
+++ b/components/sr-comp-stream/component.html
@@ -45,6 +45,11 @@
                     this.fire('knockouts', JSON.parse(e.data));
                 }.bind(this));
 
+                this.eventSource.addEventListener('last-released-match', function(e) {
+                    console.log("Got a 'last-released-match' event from the stream.");
+                    this.fire('last-released-match', JSON.parse(e.data));
+                }.bind(this));
+
                 this.eventSource.addEventListener('last-scored-match', function(e) {
                     console.log("Got a 'last-scored-match' event from the stream.");
                     this.fire('last-scored-match', JSON.parse(e.data));

--- a/components/sr-comp/component.html
+++ b/components/sr-comp/component.html
@@ -57,6 +57,12 @@
     </template>
 
     <script>
+        const MatchState = Object.freeze({
+            FUTURE: 'future',
+            HELD: 'held',
+            RELEASED: 'released',
+        });
+
         Polymer({
             connected: false,
             apiurl: undefined,

--- a/components/sr-comp/component.html
+++ b/components/sr-comp/component.html
@@ -57,12 +57,6 @@
     </template>
 
     <script>
-        const MatchState = Object.freeze({
-            FUTURE: 'future',
-            HELD: 'held',
-            RELEASED: 'released',
-        });
-
         Polymer({
             connected: false,
             apiurl: undefined,

--- a/components/sr-comp/component.html
+++ b/components/sr-comp/component.html
@@ -79,6 +79,7 @@
                 this.stream.addEventListener('team', clearCache);
                 this.stream.addEventListener('match', clearCache);
                 this.stream.addEventListener('knockouts', clearCache);
+                this.stream.addEventListener('last-released-match', clearCache);
                 this.stream.addEventListener('last-scored-match', clearCache);
 
                 this.stream.addEventListener('ping', function(e) {

--- a/components/sr-corner-clock-countdown/component.html
+++ b/components/sr-corner-clock-countdown/component.html
@@ -39,10 +39,6 @@
     </template>
 
     <script>
-        console.assert(
-            typeof MatchState !== "undefined",
-            "MatchState not defined. Are you missing use of sr-comp component?",
-        );
         Polymer({
             match: undefined,
             currentGameStart: undefined,
@@ -52,15 +48,15 @@
             },
             matchChanged: function() {
                 if (this.match) {
-                    this.currentGameState = this.match.state;
+                    this.currentGameIsReleased = this.match.is_released;
                     this.currentGameStart = new Date(this.match.times.game.start);
                 } else {
-                    this.currentGameState = null;
+                    this.currentGameIsReleased = null;
                     this.currentGameStart = null;
                 }
             },
             updateDisplay: function(e) {
-                if (this.currentGameState != MatchState.RELEASED) {
+                if (!this.currentGameIsReleased) {
                     this.text = null;
                     return;
                 }

--- a/components/sr-corner-clock-countdown/component.html
+++ b/components/sr-corner-clock-countdown/component.html
@@ -39,6 +39,10 @@
     </template>
 
     <script>
+        console.assert(
+            typeof MatchState !== "undefined",
+            "MatchState not defined. Are you missing use of sr-comp component?",
+        );
         Polymer({
             match: undefined,
             currentGameStart: undefined,
@@ -48,12 +52,19 @@
             },
             matchChanged: function() {
                 if (this.match) {
+                    this.currentGameState = this.match.state;
                     this.currentGameStart = new Date(this.match.times.game.start);
                 } else {
+                    this.currentGameState = null;
                     this.currentGameStart = null;
                 }
             },
             updateDisplay: function(e) {
+                if (this.currentGameState != MatchState.RELEASED) {
+                    this.text = null;
+                    return;
+                }
+
                 var now = e.detail;
                 if (now <= this.currentGameStart) {
                     var t = (this.currentGameStart - now) / 1000;

--- a/components/sr-corner-clock/component.html
+++ b/components/sr-corner-clock/component.html
@@ -41,16 +41,10 @@
                 return num < 10 ? "0" + num : num.toString();
             },
             formatTimeDelta: function(delta) {
-                var prefix = "";
-                if (delta < 0) {
-                    delta = -delta;
-                    prefix = "Starting in ";
-                }
-
                 var hoursLeft = parseInt(delta / 3600, 10);
                 var minutesLeft = parseInt((delta - hoursLeft * 3600) / 60, 10);
                 var secondsLeft = delta - hoursLeft * 3600 - minutesLeft * 60;
-                return prefix + (hoursLeft > 0 ? this.pad(hoursLeft) + ':' : '') + this.pad(minutesLeft) + ':' + this.pad(secondsLeft);
+                return (hoursLeft > 0 ? this.pad(hoursLeft) + ':' : '') + this.pad(minutesLeft) + ':' + this.pad(secondsLeft);
             },
             updateDisplay: function(e) {
                 var currentTime = e.detail;
@@ -69,7 +63,7 @@
                 } else if (currentTime <= gameStartTime) {
                     // game starting in 0-90 seconds
                     var t = (gameStartTime - currentTime) / 1000;
-                    this.text = this.formatTimeDelta(-t);
+                    this.text = "Starting in " + this.formatTimeDelta(t);
                 }
             }
         });

--- a/components/sr-corner-clock/component.html
+++ b/components/sr-corner-clock/component.html
@@ -18,10 +18,6 @@
     </template>
 
     <script>
-        console.assert(
-            typeof MatchState !== "undefined",
-            "MatchState not defined. Are you missing use of sr-comp component?",
-        );
         Polymer({
             match: undefined,
             currentGameStart: undefined,
@@ -33,12 +29,12 @@
             },
             matchChanged: function() {
                 if (this.match) {
-                    this.currentGameState = this.match.state;
+                    this.currentGameIsReleased = this.match.is_released;
                     this.currentGameRelease = new Date(this.match.times.operations.release_threshold);
                     this.currentGameStart = new Date(this.match.times.game.start);
                     this.currentGameEnd = new Date(this.match.times.game.end);
                 } else {
-                    this.currentGameState = null;
+                    this.currentGameIsReleased = null;
                     this.currentGameRelease = null;
                     this.currentGameStart = null;
                     this.currentGameEnd = null;
@@ -62,7 +58,7 @@
 
                 if (gameStartTime == null || gameEndTime == null) {
                     this.text = '';
-                } else if (currentTime >= gameReleaseTime && this.currentGameState != MatchState.RELEASED) {
+                } else if (currentTime >= gameReleaseTime && !this.currentGameIsReleased) {
                     var t = (gameStartTime - gameReleaseTime) / 1000;
                     this.text = "Hold at " + this.formatTimeDelta(t);
                 } else if (currentTime >= gameEndTime) {

--- a/components/sr-corner-clock/component.html
+++ b/components/sr-corner-clock/component.html
@@ -18,6 +18,10 @@
     </template>
 
     <script>
+        console.assert(
+            typeof MatchState !== "undefined",
+            "MatchState not defined. Are you missing use of sr-comp component?",
+        );
         Polymer({
             match: undefined,
             currentGameStart: undefined,
@@ -29,9 +33,13 @@
             },
             matchChanged: function() {
                 if (this.match) {
+                    this.currentGameState = this.match.state;
+                    this.currentGameRelease = new Date(this.match.times.operations.release_threshold);
                     this.currentGameStart = new Date(this.match.times.game.start);
                     this.currentGameEnd = new Date(this.match.times.game.end);
                 } else {
+                    this.currentGameState = null;
+                    this.currentGameRelease = null;
                     this.currentGameStart = null;
                     this.currentGameEnd = null;
                 }
@@ -48,11 +56,15 @@
             },
             updateDisplay: function(e) {
                 var currentTime = e.detail;
+                var gameReleaseTime = this.currentGameRelease;
                 var gameStartTime = this.currentGameStart;
                 var gameEndTime = this.currentGameEnd;
 
                 if (gameStartTime == null || gameEndTime == null) {
                     this.text = '';
+                } else if (currentTime >= gameReleaseTime && this.currentGameState != MatchState.RELEASED) {
+                    var t = (gameStartTime - gameReleaseTime) / 1000;
+                    this.text = "Hold at " + this.formatTimeDelta(t);
                 } else if (currentTime >= gameEndTime) {
                     // next slot starting in 0-30 seconds
                     this.text = 'Finished';


### PR DESCRIPTION
This supports the idea that a match needs to be "released" before it can actually run.

As the underlying mechanism does not change the _schedule_ times (doing so would mean that in a hold scenario they changed _constantly_), the client must be aware of the mechanism to show the right values. The idea of what the "current" match is changes and each match is marked with a state (`released`, `held` or `future`), allowing for minimal changes in clients.

This change will make the screens incompatible with earlier versions of the server which do not support this idea. Support could be maintained if desired, at the expense of additional complexity.

A side-effect of this is that in the event that a screen loses its connection to the stream, it will now automatically pause at the release threshold and show "Hold at $time". This _may_ be confusing if only one screen loses its connection, however is likely not an issue and may be preferred to the previous behaviour. (I believe previously it would continue to count down to the match start and then show nothing). Again maintaining the current behaviour may be possible with additional work.

This depends on https://github.com/PeterJCLaw/srcomp/pull/53 and https://github.com/PeterJCLaw/srcomp-http/pull/20.