### PR TITLE
Make it possible to configure the root url displayed

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,22 @@ displayed at the competition.
 
 Create a file called `config.json` based on `config.example.json`.
 
+```json
+{
+  "displayConfig": {
+    // Base url to an instance of the competition-website, shown on outside.html
+    // and intended to allow viewers to visit a page with similar information on
+    // their own device.
+    "externalUrl": "srobo.org/comp/"
+  },
+  "apiurl": "http://localhost/comp-api",
+  "streamurl": "http://localhost/stream"
+}
+```
+
+`apiurl` and `streamurl` are required and should point to instances of the SRComp HTTP API and Stream respectively.
+`displayConfig` is optional and if present its keys will be merged with the defaults (the above values are the defaults).
+
 ## Installation & Running
 
 Dependencies are managed with [Yarn](https://yarnpkg.com/getting-started/install),

--- a/components/sr-comp/component.html
+++ b/components/sr-comp/component.html
@@ -3,7 +3,7 @@
 <link rel="import" href="../sr-comp-api/component.html" />
 <link rel="import" href="../sr-comp-stream/component.html" />
 
-<polymer-element name="sr-comp" attributes="apiurl streamurl">
+<polymer-element name="sr-comp" attributes="displayConfig apiurl streamurl">
     <template>
         <style>
             #error {
@@ -45,7 +45,7 @@
           auto
           url="../../config.json"
           handleAs="json"
-          on-core-response="{{ gotUrls }}"></core-ajax>
+          on-core-response="{{ gotConfig }}"></core-ajax>
 
         <sr-comp-api id="api" url="{{ apiurl }}"></sr-comp-api>
         <sr-comp-stream id="stream" url="{{ streamurl }}"></sr-comp-stream>
@@ -57,8 +57,13 @@
     </template>
 
     <script>
+        const DEFAULT_DISPLAY_CONFIG = {
+            externalUrl: "srobo.org/comp/",
+        };
+
         Polymer({
             connected: false,
+            displayConfig: DEFAULT_DISPLAY_CONFIG,
             apiurl: undefined,
             streamurl: undefined,
             pingTimeout: undefined,
@@ -116,10 +121,12 @@
             connectedChanged: function() {
                 this.$.error.hidden = this.connected;
             },
-            gotUrls: function(e) {
-                var urls = e.detail.response;
-                this.apiurl = urls.apiurl;
-                this.streamurl = urls.streamurl;
+            gotConfig: function(e) {
+                var response = e.detail.response;
+                this.displayConfig = { ...DEFAULT_DISPLAY_CONFIG, ...response.displayConfig };
+                console.log("Display config:", this.displayConfig);
+                this.apiurl = response.apiurl;
+                this.streamurl = response.streamurl;
             }
         });
     </script>

--- a/config.example.json
+++ b/config.example.json
@@ -1,4 +1,7 @@
 {
+  "displayConfig": {
+    "externalUrl": "srobo.org/comp/"
+  },
   "apiurl": "http://localhost/comp-api",
   "streamurl": "http://localhost/stream"
 }

--- a/outside.html
+++ b/outside.html
@@ -160,7 +160,7 @@
                 var nextPage = function() {
                     pages.selected = (pages.selected + 1) % pages.children.length;
                     progressTitle.textContent = pages.children[pages.selected].dataset.title;
-                    websiteUrl.textContent = "srobo.org/comp/" + pages.children[pages.selected].dataset.websiteUrlSlug;
+                    websiteUrl.textContent = comp.displayConfig.externalUrl + pages.children[pages.selected].dataset.websiteUrlSlug;
                     progress.progress = 0;
                 };
 


### PR DESCRIPTION
This introduces a generic way to configure display related things and then uses it to allow the "srobo.org/comp/" part of the url displayed to viewers to be configured.