### PR TITLE
Support hiding some "outside" pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,11 @@ Create a file called `config.json` based on `config.example.json`.
     // Base url to an instance of the competition-website, shown on outside.html
     // and intended to allow viewers to visit a page with similar information on
     // their own device.
-    "externalUrl": "srobo.org/comp/"
+    "externalUrl": "srobo.org/comp/",
+    // Pages within the rotating collection used by outside.html which should be
+    // hidden. For example if a competition does not want to show the knockout
+    // page then this would be ["sr-knockout-diagram"].
+    "hideOutsidePages": []
   },
   "apiurl": "http://localhost/comp-api",
   "streamurl": "http://localhost/stream"

--- a/components/sr-comp/component.html
+++ b/components/sr-comp/component.html
@@ -58,6 +58,7 @@
 
     <script>
         const DEFAULT_DISPLAY_CONFIG = {
+            hideOutsidePages: [],
             externalUrl: "srobo.org/comp/",
         };
 

--- a/config.example.json
+++ b/config.example.json
@@ -1,6 +1,7 @@
 {
   "displayConfig": {
-    "externalUrl": "srobo.org/comp/"
+      "externalUrl": "srobo.org/comp/",
+      "hideOutsidePages": []
   },
   "apiurl": "http://localhost/comp-api",
   "streamurl": "http://localhost/stream"

--- a/outside.html
+++ b/outside.html
@@ -165,12 +165,13 @@
                 };
 
                 var shouldSelectAutomatically = function(index) {
-                    if (index == 3) {  // knockouts
+                    const tagName = pages.children[index].tagName.toLowerCase();
+                    if (tagName == 'sr-knockout-diagram') {
                         if (knockoutTime != null && moment().isBefore(knockoutTime)) {
                             return false;
                         }
                     }
-                    if (index == 1) {  // leaderboard
+                    if (tagName == 'sr-leaderboard') {
                         if (noLeaderboardTime != null && moment().isAfter(noLeaderboardTime)) {
                             return false;
                         }

--- a/outside.html
+++ b/outside.html
@@ -166,6 +166,9 @@
 
                 var shouldSelectAutomatically = function(index) {
                     const tagName = pages.children[index].tagName.toLowerCase();
+                    if (comp.displayConfig.hideOutsidePages.includes(tagName)) {
+                        return false;
+                    }
                     if (tagName == 'sr-knockout-diagram') {
                         if (knockoutTime != null && moment().isBefore(knockoutTime)) {
                             return false;


### PR DESCRIPTION
Currently the pages on the "outside" screen are controlled entirely by the screen itself. This PR introduces a mechanism to hide some pages based on their `tagName`.

Builds on https://github.com/srobo/srcomp-screens/pull/14