### PR TITLE
Improve choice of which knockout rounds are shown

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,9 @@ Create a file called `config.json` based on `config.example.json`.
     // Pages within the rotating collection used by outside.html which should be
     // hidden. For example if a competition does not want to show the knockout
     // page then this would be ["sr-knockout-diagram"].
-    "hideOutsidePages": []
+    "hideOutsidePages": [],
+    // How many "rounds" to show on the knockouts page of the "outside" screen.
+    "maxKnockoutRounds": 5
   },
   "apiurl": "http://localhost/comp-api",
   "streamurl": "http://localhost/stream"

--- a/components/sr-comp/component.html
+++ b/components/sr-comp/component.html
@@ -60,6 +60,7 @@
         const DEFAULT_DISPLAY_CONFIG = {
             hideOutsidePages: [],
             externalUrl: "srobo.org/comp/",
+            maxKnockoutRounds: 5,
         };
 
         Polymer({

--- a/components/sr-knockout-diagram/component.html
+++ b/components/sr-knockout-diagram/component.html
@@ -155,12 +155,35 @@
                 }.bind(this));
             },
             sliceRounds: function(rounds) {
-                var start = rounds.length - this.comp.displayConfig.maxKnockoutRounds;
-                if (start < 0) {
-                  start = 0;
+                const maxKnockoutRounds = this.comp.displayConfig.maxKnockoutRounds;
+                if (rounds.length <= maxKnockoutRounds) {
+                    return rounds;
                 }
 
-                return rounds.slice(start);
+                // Find the last match which has been scored. Scored matches
+                // have definitely been played.
+                let lastScoredMatchRoundIndex = 0;
+                rounds.forEach((round, roundIdx) => {
+                    round.forEach(match => {
+                        if (!!match.scores) {
+                            lastScoredMatchRoundIndex = roundIdx;
+                        }
+                    });
+                });
+
+                const start = Math.min(
+                    lastScoredMatchRoundIndex,
+                    rounds.length - maxKnockoutRounds,
+                );
+
+                console.debug("Rounds slicing", {
+                    start,
+                    lastScoredMatchRoundIndex,
+                    maxKnockoutRounds,
+                    roundsLength: rounds.length,
+                })
+
+                return rounds.slice(start, start + maxKnockoutRounds);
             },
             updateDiagram: function() {
                 if (this.arenas == null || this.corners == null) {

--- a/components/sr-knockout-diagram/component.html
+++ b/components/sr-knockout-diagram/component.html
@@ -170,7 +170,7 @@
                 }.bind(this));
             },
             sliceRounds: function(rounds) {
-                var start = rounds.length - 5;
+                var start = rounds.length - this.comp.displayConfig.maxKnockoutRounds;
                 if (start < 0) {
                   start = 0;
                 }

--- a/components/sr-knockout-diagram/component.html
+++ b/components/sr-knockout-diagram/component.html
@@ -121,26 +121,11 @@
             };
         }();
 
-        var processKnockouts = function(rounds, tiebreaker) {
+        var processKnockouts = function(rounds) {
             var output = [];
             for (var i = 0; i < rounds.length; i++) {
                 output.push(process_knockout_round(rounds[i]));
             }
-
-            if (tiebreaker) {
-                output.push([
-                    {
-                        'number': tiebreaker.num,
-                        'description': tiebreaker.display_name,
-                        'time': new Date(tiebreaker.times.slot.start),
-                        'games': [{
-                            'arena': tiebreaker.arena,
-                            'teams': tiebreaker.teams
-                        }]
-                    }
-                ]);
-            }
-
             return output;
         };
 
@@ -184,7 +169,10 @@
 
                 this.comp.api.getKnockout(function(rounds) {
                     this.comp.api.getTiebreaker(function(tiebreaker) {
-                        this.rounds = processKnockouts(this.sliceRounds(rounds), tiebreaker);
+                        if (tiebreaker) {
+                            rounds = [...rounds, [tiebreaker]];
+                        }
+                        this.rounds = processKnockouts(this.sliceRounds(rounds));
 
                         this.style.fontSize = Math.sqrt(5 / this.rounds.length) + 'em';
                     }.bind(this));

--- a/config.example.json
+++ b/config.example.json
@@ -1,7 +1,8 @@
 {
   "displayConfig": {
       "externalUrl": "srobo.org/comp/",
-      "hideOutsidePages": []
+      "hideOutsidePages": [],
+      "maxKnockoutRounds": 5
   },
   "apiurl": "http://localhost/comp-api",
   "streamurl": "http://localhost/stream"


### PR DESCRIPTION
This:
- makes the number of knockout rounds shown configurable, and
- uses whether or not matches in a round have been scored to indicate which rounds should be shown -- starting with the leftmost and only letting matches drop off once they've all been scored

This has the consequence that if the configured number is too small we could end up with matches which are about to be played not actually being shown, however that doesn't feel particularly likely given how the rounds relate to each other -- that scores from earlier matches determine which teams are in later ones.

<img width="1534" height="1057" alt="image" src="https://github.com/user-attachments/assets/496d1584-e455-4c09-b9f8-949fa9d7cbc9" />

Builds on https://github.com/srobo/srcomp-screens/pull/15
