### PR TITLE
Add support for splitting knockout diagrams by bracket

### DIFF
--- a/components/sr-comp-api/component.html
+++ b/components/sr-comp-api/component.html
@@ -170,6 +170,18 @@
                     callback(response.rounds);
                 });
             },
+            getKnockoutStructure: function(callback) {
+                this._apiCall('/knockout/structure', function(response) {
+                    callback(response);
+                }, function(err) {
+                    // Compatibility fallback
+                    callback({
+                        'brackets': [
+                            {'name': null, 'display_name': "Knockouts"},
+                        ],
+                    });
+                });
+            },
             getTiebreaker: function(callback) {
                 this._apiCall('/tiebreaker', function(response) {
                     callback(response.tiebreaker, undefined);

--- a/components/sr-comp-stream/component.html
+++ b/components/sr-comp-stream/component.html
@@ -45,6 +45,11 @@
                     this.fire('knockouts', JSON.parse(e.data));
                 }.bind(this));
 
+                this.eventSource.addEventListener('knockout-structure', function(e) {
+                    console.log("Got a 'knockout-structure' event from the stream.");
+                    this.fire('knockout-structure', JSON.parse(e.data));
+                }.bind(this));
+
                 this.eventSource.addEventListener('last-scored-match', function(e) {
                     console.log("Got a 'last-scored-match' event from the stream.");
                     this.fire('last-scored-match', JSON.parse(e.data));

--- a/components/sr-knockout-diagram/component.html
+++ b/components/sr-knockout-diagram/component.html
@@ -8,7 +8,7 @@
                 font-size: 0.5em;
             }
 
-            #knockout {
+            .knockout-diagram {
                 display: flex;
                 display: -webkit-flex;
                 align-items: center;
@@ -44,7 +44,7 @@
             }
         </style>
 
-        <div id="knockout">
+        <div class="knockout-diagram">
             <template repeat="{{ round, i in rounds }}">
                 <div class="round">
                     <template repeat="{{ match in round }}">

--- a/components/sr-knockout-diagram/component.html
+++ b/components/sr-knockout-diagram/component.html
@@ -131,6 +131,7 @@
 
         Polymer({
             comp: null,
+            bracket: null,
             arenas: undefined,
             corners: undefined,
             rounds: undefined,
@@ -153,6 +154,21 @@
                     this.corners = corners;
                     this.updateDiagram();
                 }.bind(this));
+            },
+            filterRounds: function(rounds) {
+                // Filter out rounds which don't match our given knockout
+                // bracket, including filtering out entire rounds which aren't
+                // from our bracket.
+                return rounds.map(round => {
+                    return round.filter(match => {
+                        // Rely on sr-comp-api wrapper's compatibility fallback
+                        // response to the structure of the knockouts setting
+                        // the bracket to `null` for older SRComp HTTP APIs
+                        // which don't provide the structure data and thus don't
+                        // have the knockout_bracket property.
+                        return match.knockout_bracket == this.bracket;
+                    })
+                }).filter(x => x.length > 0);
             },
             sliceRounds: function(rounds) {
                 const maxKnockoutRounds = this.comp.displayConfig.maxKnockoutRounds;
@@ -195,7 +211,11 @@
                         if (tiebreaker) {
                             rounds = [...rounds, [tiebreaker]];
                         }
-                        this.rounds = processKnockouts(this.sliceRounds(rounds));
+                        this.rounds = processKnockouts(
+                            this.sliceRounds(
+                                this.filterRounds(rounds),
+                            ),
+                        );
 
                         this.style.fontSize = Math.sqrt(5 / this.rounds.length) + 'em';
                     }.bind(this));

--- a/outside.html
+++ b/outside.html
@@ -143,7 +143,7 @@
                     newDiagram.dataset.title = title;
                     newDiagram.dataset.websiteUrlSlug = 'knockout';
                     pages.appendChild(newDiagram);
-                }
+                };
 
                 comp.api.getKnockoutStructure(function(structure) {
                     structure.brackets.forEach(x => appendKnockoutsDiagram(x.display_name, x.name));

--- a/outside.html
+++ b/outside.html
@@ -149,7 +149,6 @@
                     // Remove existing entries, then rebuild
                     pages.children.array().forEach(child => {
                         if (child.tagName.toLowerCase() == 'sr-knockout-diagram') {
-                            console.log("Removing", child)
                             child.parentNode.removeChild(child);
                         }
                     });

--- a/outside.html
+++ b/outside.html
@@ -117,11 +117,7 @@
                 data-website-url-slug="league"
                 data-needs-comp
             ></sr-scores>
-            <sr-knockout-diagram
-                data-title="Knockouts"
-                data-website-url-slug="knockout"
-                data-needs-comp
-            ></sr-knockout-diagram>
+            <!-- sr-knockout-diagram added dynamically inline below -->
         </core-pages>
 
         <sr-progress id="progress" progress="1">
@@ -132,11 +128,26 @@
 
         <script>
             document.addEventListener('sr-ready', function() {
+                const pages = document.querySelector('#pages');
+
                 var comp = document.querySelector('#comp');
                 var needsComp = document.querySelectorAll('[data-needs-comp]');
                 for (var i = 0; i < needsComp.length; i++) {
                     needsComp[i].comp = comp;
                 }
+
+                const appendKnockoutsDiagram = function(title, bracket) {
+                    const newDiagram = document.createElement('sr-knockout-diagram');
+                    newDiagram.comp = comp;
+                    newDiagram.bracket = bracket;
+                    newDiagram.dataset.title = title;
+                    newDiagram.dataset.websiteUrlSlug = 'knockout';
+                    pages.appendChild(newDiagram);
+                }
+
+                comp.api.getKnockoutStructure(function(structure) {
+                    structure.brackets.forEach(x => appendKnockoutsDiagram(x.display_name, x.name));
+                });
 
                 var knockoutTime = undefined;
                 var noLeaderboardTime = undefined;
@@ -152,7 +163,6 @@
                     }
                 });
 
-                var pages = document.querySelector('#pages');
                 var progress = document.querySelector('#progress');
                 var progressTitle = document.querySelector('#progress-title');
                 var websiteUrl = document.querySelector('#website-url');

--- a/outside.html
+++ b/outside.html
@@ -145,9 +145,20 @@
                     pages.appendChild(newDiagram);
                 };
 
-                comp.api.getKnockoutStructure(function(structure) {
-                    structure.brackets.forEach(x => appendKnockoutsDiagram(x.display_name, x.name));
-                });
+                const updateKnockoutsDiagrams = function(structure) {
+                    // Remove existing entries, then rebuild
+                    pages.children.array().forEach(child => {
+                        if (child.tagName.toLowerCase() == 'sr-knockout-diagram') {
+                            console.log("Removing", child)
+                            child.parentNode.removeChild(child);
+                        }
+                    });
+                    structure.brackets.forEach(bracket => appendKnockoutsDiagram(bracket.display_name, bracket.name));
+                };
+
+                // Ideally we'd only use the stream, however older versions of the backends don't offer this event.
+                comp.stream.addEventListener('knockout-structure', e => updateKnockoutsDiagrams(e.detail));
+                comp.api.getKnockoutStructure(updateKnockoutsDiagrams);
 
                 var knockoutTime = undefined;
                 var noLeaderboardTime = undefined;


### PR DESCRIPTION
This includes some proposed changes to the SRComp HTTP API, which must expose new information so clients can understand the brackets.

For this to work we'd need to deploy the following in addition, however the code here is backwards compatible without these changes:
- https://github.com/PeterJCLaw/srcomp-stream/pull/10 (or https://github.com/WillB97/srcomp-pystream/pull/15)
- https://github.com/PeterJCLaw/srcomp-http/pull/23
- https://github.com/PeterJCLaw/srcomp/pull/56

For SR2025's brackets:

<img width="1492" height="975" alt="image" src="https://github.com/user-attachments/assets/9fcc47ec-8a2c-4736-9ffa-a5dad7741bd7" />

<img width="1492" height="975" alt="image" src="https://github.com/user-attachments/assets/4bcf4304-384c-408e-9c98-2b3f791a0b47" />
