### PR TITLE
Allow staging corner columns to be customised

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,13 @@ Create a file called `config.json` based on `config.example.json`.
     // page then this would be ["sr-knockout-diagram"].
     "hideOutsidePages": [],
     // How many "rounds" to show on the knockouts page of the "outside" screen.
-    "maxKnockoutRounds": 5
+    "maxKnockoutRounds": 5,
+    // Used to control the corner columns as shown on the staging screen (useful
+    // if the table doesn't match the default ordering). If the set of corners
+    // doesn't match the set of corners configured in the compstate (usually
+    // `["0", "1", "2", "3"]`), a warning is printed to the browser console
+    // and the default corners are used.
+    "stagingCornersList": ["0", "3", "2", "1"]
   },
   "apiurl": "http://localhost/comp-api",
   "streamurl": "http://localhost/stream"

--- a/components/sr-comp/component.html
+++ b/components/sr-comp/component.html
@@ -61,6 +61,7 @@
             hideOutsidePages: [],
             externalUrl: "srobo.org/comp/",
             maxKnockoutRounds: 5,
+            stagingCornersList: undefined,
         };
 
         Polymer({

--- a/components/sr-staging-schedule/component.html
+++ b/components/sr-staging-schedule/component.html
@@ -128,7 +128,19 @@
 
                 this.comp.api.getCorners(function(corners) {
                     this.corners = corners;
-                    this.cornersList = Object.keys(corners);
+
+                    var validCornersList = Object.keys(corners);
+                    var proposedCornersList = this.comp.displayConfig.stagingCornersList || validCornersList;
+
+                    if (new Set(validCornersList).symmetricDifference(new Set(proposedCornersList)).size !== 0) {
+                        console.warn("Corner list configuration mismatch with valid corners.");
+                        console.warn("Valid corners are: ", validCornersList);
+                        console.warn("Falling back to valid corners.");
+                        proposedCornersList = validCornersList;
+                    }
+
+                    this.cornersList = proposedCornersList;
+
                     this.updateSchedule();
                 }.bind(this));
 

--- a/config.example.json
+++ b/config.example.json
@@ -2,7 +2,8 @@
   "displayConfig": {
       "externalUrl": "srobo.org/comp/",
       "hideOutsidePages": [],
-      "maxKnockoutRounds": 5
+      "maxKnockoutRounds": 5,
+      "stagingCornersList": ["0", "3", "2", "1"]
   },
   "apiurl": "http://localhost/comp-api",
   "streamurl": "http://localhost/stream"


### PR DESCRIPTION
This allows the corners of the staging screen to be ordered if the staging table doesn't match the default ordering, to make it easier for badgers to put the teams in the right slot.

## Screenshots

<img width="1470" height="509" alt="Screenshot 2026-04-11 at 11 19 15" src="https://github.com/user-attachments/assets/949dd2c6-dda9-44b7-93cc-eb8470605241" />

<img width="406" height="80" alt="Screenshot 2026-04-11 at 11 13 32" src="https://github.com/user-attachments/assets/ad082be8-ee20-468a-8610-e9a60141d498" />
