### PR TITLE
Add corner headings to staging table

### DIFF
--- a/components/sr-staging-schedule/component.html
+++ b/components/sr-staging-schedule/component.html
@@ -32,12 +32,27 @@
 
         <table>
             <tr>
-                <th></th>
-                <th>Match Starts</th>
-                <th>Staging Opens</th>
+                <th rowspan="2"></th>
+                <th rowspan="2">Match Starts</th>
+                <th rowspan="2">Staging Opens</th>
                 <template repeat="{{ arena in arenasList }}">
                     <th></th>
-                    <th colspan="{{ cornersList.length }}" style="background-color: {{ arenas[arena].colour | arenaColour }}">{{ arenas[arena].display_name }}</th>
+                    <th colspan="{{ cornersList.length }}" style="background-color: {{ arenas[arena].colour | arenaColour }}">
+                        {{ arenas[arena].display_name }}
+                    </th>
+                </template>
+            </tr>
+
+            <tr>
+                <template repeat="{{ arena in arenasList }}">
+                    <th></th>
+                    <template repeat="{{ corner in cornersList }}">
+                        <th style="background-color: {{ arenas[arena].colour | arenaColour }}">
+                            <span style="color: {{ corners[corner].colour }}">
+                                {{ corners[corner].number }}
+                            </span>
+                        </th>
+                    </template>
                 </template>
             </tr>
 


### PR DESCRIPTION
This makes it much clearer to see which column aligns to which corner, especially if it's out of the default order. This should speed up how teams go to the staging table before their match.

## Screenshot

<img width="1511" height="676" alt="Screenshot 2026-04-12 at 11 22 23" src="https://github.com/user-attachments/assets/07ec3d6f-39d1-4daf-b77a-d4e0d8305ee1" />

